### PR TITLE
added the .remove method required to delete product from an order

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,7 @@
             "name": "db",
             "database": "db.sqlite3"
         }
-    ]
+    ],
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
 }

--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -247,6 +247,7 @@ class ProductView(ViewSet):
             product = Product.objects.get(pk=pk)
             order = Order.objects.get(
                 user=request.auth.user, completed_on=None)
+            order.products.remove(product)
             return Response(None, status=status.HTTP_204_NO_CONTENT)
         except Product.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Description
In `product_view.py`, modified the custom action to remove a product from the users open order to include a `.remove()` method.
New code on line 250.
Fixes issue # 4

### Type of change
- Bug fix (non-breaking change which fixes an issue)

### Testing Instructions
If you haven't already, follow the instructions in the README.md to create a user in Swagger. 
To test the remove method, you will first need to add a product to your order (POST /products/{id}/add_to_order).
Then, check your current order (GET /orders/current) to ensure there is an item to remove.
Then, test the remove method using the id of the item you want to remove (DELETE /products/{id}/remove_from_order)
