### PR TITLE
Mc filter by min price

### DIFF
--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -165,6 +165,7 @@ class ProductView(ViewSet):
         category = request.query_params.get('category', None)
         order = request.query_params.get('order_by', None)
         direction = request.query_params.get('direction', None)
+        min_price = request.query_params.get('min_price', None)
 
         if number_sold:
             products = products.annotate(
@@ -177,6 +178,9 @@ class ProductView(ViewSet):
 
         if category is not None:
             products = products.filter(category__id=category)
+
+        if min_price is not None:
+            products = products.filter(price__gte=min_price)
 
         serializer = ProductSerializer(products, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
# Description
In `product_view.py`, added a new possible filter on the `list()` function. 
Added the `min_price` query param, and then an if block referring to that param, in which the products are filtered by minimum price (greater than or equal to). 
Fixes  issue # 7

## Type of change
- New feature (non-breaking change which adds functionality)

## Testing Instructions
In Swagger, after you authorize with a token, select `GET /products`, then press `Try it out`.
One of the possible filters will be minimum price. Enter the price of your choice and `execute`. 
The list returned should only have products that have a price equal to or greater than the price you specified as a filter.
