### PR TITLE
fixed the view profile to display profile of currently loggged in user

### DIFF
--- a/bangazon_api/views/profile_view.py
+++ b/bangazon_api/views/profile_view.py
@@ -28,7 +28,7 @@ class ProfileView(ViewSet):
     def my_profile(self, request):
         """Get the current user's profile"""
         try:
-            serializer = UserSerializer(User.objects.first())
+            serializer = UserSerializer(User.objects.get(pk=request.auth.user.id))
             return Response(serializer.data)
         except User.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Description
In `profile_view.py`, modified the serializer to get the user currently logged in instead of `.first()`.

### Type of change
- Bug fix (non-breaking change which fixes an issue)


### Testing Instructions
Login a user in Swagger, then `GET /profile/my-profile`. The user logged in should be the one displayed.

